### PR TITLE
Fixed bug where 'index' column was named 'n_db_id' after reset_index

### DIFF
--- a/goodneighbors/__init__.py
+++ b/goodneighbors/__init__.py
@@ -242,6 +242,9 @@ class GoodNeighbors(object):
             ids = pd.DataFrame({'db_id':one.index.tolist()})
             ids['_key'] = 1
             cnts = ids.merge(phenotypes,on='_key').drop(columns=['_key']).merge(cnts,on=['db_id','phenotype_label'],how='left').fillna(0)
+            if 'index' not in cnts.columns:
+                # If there's only a few rows, sometimes the 'index' column is named 'n_db_id' from the reset_index()
+                cnts = cnts.rename(columns={"n_db_id": "index"})
             cnts['index'] = cnts['index'].astype(int)
             cnts = cnts.pivot(columns='phenotype_label',index='db_id',values='index')
 


### PR DESCRIPTION
When the number of cells in a frame is just one or two, there's an error. At line 240 there are some merges and reset_index()'s that moves the index to its own column called index. When there are only one or two rows in the dataframe, when that happens the new column isn't called index, it retains its name from before which is n_db_id. I added a few lines to check if index is a column and if not, rename the n_db_id column to index. Then things continue fine.